### PR TITLE
Allow UI to open Jobs with special characters in their ID

### DIFF
--- a/src/server/views/dashboard/templates/queueJobsByState.hbs
+++ b/src/server/views/dashboard/templates/queueJobsByState.hbs
@@ -86,14 +86,14 @@
         {{#each jobs}}
           <li class="list-group-item">
             <div class="js-bulk-action-container bulk-job-container">
-              <input type="hidden" name="jobId" value="{{ this.id }}" />
+              <input type="hidden" name="jobId" value="{{this.id }}" />
               <input class="js-bulk-job" name="jobChecked" type="checkbox" />
             </div>
 
-            <a role="button" data-toggle="collapse" href="#collapse{{this.id}}">
-              <h4 class="header-collapse">{{ this.id }}</h4>
+            <a role="button" data-toggle="collapse" href="#collapse{{encodeIdAttr this.id}}">
+              <h4 class="header-collapse">{{this.id }}</h4>
             </a>
-            <div id="collapse{{this.id}}" class="collapse">
+            <div id="collapse{{encodeIdAttr this.id}}" class="collapse">
               {{> dashboard/jobDetails this basePath=../basePath displayJobInline=true queueName=../queueName queueHost=../queueHost jobState=../state }}
             </div>
           </li>

--- a/src/server/views/helpers/handlebars.js
+++ b/src/server/views/helpers/handlebars.js
@@ -24,6 +24,10 @@ const helpers = {
     var blocks = this._blocks || (this._blocks = {});
         block = blocks[name] || (blocks[name] = []);
     block.push(options.fn(this));
+  },
+  
+  encodeIdAttr: function (id) {
+      return id.replace(/:| /g, "");
   }
 };
 


### PR DESCRIPTION
Jobs that have ids with special characters do not work when trying to create collapse-able areas with unique IDs